### PR TITLE
use correct object in warnings (fix warnings misc method)

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -713,16 +713,9 @@ export class Client {
     warnings(): Promise<ErrorWarning[]> {
         return new Promise<ErrorWarning[]>(async (resolve, reject) => {
             try {
-                let results = await this.methodCall("warnings");
-                let warnings: ErrorWarning[] = [];
-
-                for( let result of results ) {
-                    if( !result.text || result.type !== "WARNING" || !result.time )
-                        reject(new Error("Invalid response from SABnzbd"));
-                    warnings.push({text: result.text, type: ErrorType.Warning, time: result.time});    
-                }
-
-                resolve(warnings);
+                let resultsObj = yield this.methodCall("warnings");
+                let results = resultsObj.warnings;
+                resolve(results);
             } catch( error ) {
                 reject(error);
             }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -4,13 +4,15 @@
 //   Written By Jeremy Harmon <jeremy.harmon@zoho.com>
 
 export enum ErrorType {
-    Warning
+    WARNING="WARNING",
+    ERROR="ERROR"
 }
 
 export interface ErrorWarning {
     text: string,
     type: ErrorType,
     time: number
+    origin?: string
 }
 
 export interface ServerStats {


### PR DESCRIPTION
The `warnings` method would error out:

```bash
TypeError: results is not iterable
```

This is because it would directly query the result object rather than the `warnings` key.
I used similar code as the `history` command to properly query and return.